### PR TITLE
Aikido Safe Chain Support

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install Hatch
       uses: pypa/hatch@install
     - name: configure git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install Hatch
       uses: pypa/hatch@install
     - run: hatch fmt --check
@@ -33,7 +33,7 @@ jobs:
         - 3.12
         - 3.13
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install Hatch
       uses: pypa/hatch@install
     - name: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ packages = [
 src = ""
 
 [tool.hatch.envs.default]
+path = ".venv"
 python = "3.10"
 dependencies = [
     "mypy",
@@ -85,8 +86,10 @@ extra-dependencies = [
     "tox",
     "black",
 ]
-extra-arguments = [
+extra-args = [
     "--cache-clear",
+    "-s",
+    "-vv",
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -527,7 +527,7 @@ def is_aliased(command: str) -> bool:
         shell_output: str = check_output(  # noqa: S604
             (WHICH, command),
             shell=True,
-        ).rstrip()
+        )
     except CalledProcessError:
         return False
     return shell_output.strip() != which_command.strip()

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -530,7 +530,7 @@ def is_aliased(command: str) -> bool:
         )
     except CalledProcessError:
         return False
-    return shell_output.strip() != which_command.strip()
+    return shell_output.strip().lower() != which_command.strip().lower()
 
 
 def _iter_pip_list() -> Iterable[tuple[str, PackageMetadata]]:

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -216,6 +216,8 @@ def check_output(
         (
             list2cmdline(args)
             if (shell and not default_shell)
+            else (default_shell, list2cmdline(args))
+            if default_shell and os.name == "nt"
             else (default_shell, "-i", "-c", list2cmdline(args))
             if default_shell
             else args

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 
 _BUILTIN_DISTRIBUTION_NAMES: tuple[str] = ("distribute",)
 _UNSAFE_CHARACTERS_PATTERN: re.Pattern = re.compile("[^A-Za-z0-9.]+")
+WHICH: str = "where" if os.name == "nt" else "which"
 
 
 class DefinitionExistsError(Exception):
@@ -519,7 +520,7 @@ def is_aliased(command: str) -> bool:
         return False
     try:
         shell_output: str = check_output(  # noqa: S604
-            ("which", command),
+            (WHICH, command),
             shell=True,
         )
     except CalledProcessError:

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -217,7 +217,10 @@ def check_output(
             list2cmdline(args)
             if (shell and not default_shell)
             else (default_shell, list2cmdline(args))
-            if default_shell and os.name == "nt"
+            if default_shell
+            and default_shell.endswith(("pwsh.exe", "powershell.exe"))
+            else (default_shell, "/c", list2cmdline(args))
+            if default_shell and default_shell.endswith("cmd.exe")
             else (default_shell, "-i", "-c", list2cmdline(args))
             if default_shell
             else args

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -527,7 +527,7 @@ def is_aliased(command: str) -> bool:
         shell_output: str = check_output(  # noqa: S604
             (WHICH, command),
             shell=True,
-        )
+        ).rstrip()
     except CalledProcessError:
         return False
     return shell_output.strip() != which_command.strip()

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -192,6 +192,8 @@ def check_output(
     cwd: str | Path = "",
     *,
     echo: bool = False,
+    shell: bool = False,
+    env: dict[str, str] | None = None,
 ) -> str:
     """
     This function mimics `subprocess.check_output`, but redirects stderr
@@ -206,12 +208,23 @@ def check_output(
             print("$", "cd", cwd, "&&", list2cmdline(args))  # noqa: T201
         else:
             print("$", list2cmdline(args))  # noqa: T201
+    default_shell: str | None = (
+        (os.getenv("SHELL") or os.getenv("COMSPEC")) if shell else None
+    )
     output: str = run(
-        args,
+        (
+            list2cmdline(args)
+            if (shell and not default_shell)
+            else (default_shell, "-i", "-c", list2cmdline(args))
+            if default_shell
+            else args
+        ),
         stdout=PIPE,
         stderr=DEVNULL,
         check=True,
         cwd=cwd or None,
+        shell=(shell and not default_shell),
+        env=env,
     ).stdout.decode("utf-8", errors="ignore")
     if echo:
         print(output)  # noqa: T201
@@ -493,6 +506,21 @@ class PackageMetadata(TypedDict, total=False):
     name: str
     version: str
     editable_project_location: str
+
+
+@cache
+def is_aliased(command: str) -> bool:
+    """
+    Determine if the command is aliased in the default shell environment.
+    """
+    try:
+        shell_output: str = check_output(  # noqa: S604
+            ("which", command),
+            shell=True,
+        )
+    except CalledProcessError:
+        return False
+    return shell_output.strip() != (shutil.which(command) or "").strip()
 
 
 def _iter_pip_list() -> Iterable[tuple[str, PackageMetadata]]:
@@ -1091,7 +1119,11 @@ def _install_requirement_string(
     """
     command: tuple[str, ...]
     uv: str | None = shutil.which("uv")
+    shell: bool = False
     if uv:
+        if is_aliased("uv"):
+            shell = True
+            uv = "uv"
         command = (
             uv,
             "pip",
@@ -1111,11 +1143,23 @@ def _install_requirement_string(
         )
     else:
         # If `uv` is not available, use `pip`
+        if is_aliased("pip"):
+            shell = True
+            command = (
+                "pip",
+                "install",
+                "--python",
+                sys.executable,
+            )
+        else:
+            command = (
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+            )
         command = (
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
+            *command,
             "--no-deps",
             "--no-compile",
             *(
@@ -1128,7 +1172,7 @@ def _install_requirement_string(
             ),
         )
     try:
-        check_output(command)
+        check_output(command, shell=shell)
     except CalledProcessError as error:
         message: str = (
             (
@@ -1153,7 +1197,7 @@ def _install_requirement_string(
             print(message)  # noqa: T201
             raise
         try:
-            check_output((*command, "--force-reinstall"))
+            check_output((*command, "--force-reinstall"), shell=shell)
         except CalledProcessError:
             print(message)  # noqa: T201
             raise

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -513,6 +513,10 @@ def is_aliased(command: str) -> bool:
     """
     Determine if the command is aliased in the default shell environment.
     """
+    which_command: str | None = shutil.which(command)
+    if not which_command:
+        # The command does not exist
+        return False
     try:
         shell_output: str = check_output(  # noqa: S604
             ("which", command),
@@ -520,7 +524,7 @@ def is_aliased(command: str) -> bool:
         )
     except CalledProcessError:
         return False
-    return shell_output.strip() != (shutil.which(command) or "").strip()
+    return shell_output.strip() != which_command.strip()
 
 
 def _iter_pip_list() -> Iterable[tuple[str, PackageMetadata]]:

--- a/src/dependence/upgrade.py
+++ b/src/dependence/upgrade.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 import sys
 from itertools import chain
 from typing import TYPE_CHECKING
 
 from dependence._utilities import (
     check_output,
+    is_aliased,
     iter_configuration_files,
     iter_parse_delimited_values,
 )
@@ -80,15 +82,45 @@ def upgrade(
         exclude_pointers=exclude_pointers,
     )
     if frozen_requirements:
-        command: tuple[str, ...] = (
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "--upgrade",
-            *frozen_requirements,
-        )
-        check_output(command, echo=echo)
+        command: tuple[str, ...]
+        uv: str | None = shutil.which("uv")
+        shell: bool = False
+        if uv:
+            if is_aliased("uv"):
+                shell = True
+                uv = "uv"
+            command = (
+                uv,
+                "pip",
+                "install",
+                "--python",
+                sys.executable,
+                "--upgrade",
+                *frozen_requirements,
+            )
+        else:
+            # If `uv` is not available, use `pip`
+            if is_aliased("pip"):
+                shell = True
+                command = (
+                    "pip",
+                    "install",
+                    "--python",
+                    sys.executable,
+                )
+            else:
+                command = (
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                )
+            command = (
+                *command,
+                "--upgrade",
+                *frozen_requirements,
+            )
+        check_output(command, shell=shell, echo=echo)
     configuration_files: tuple[str, ...] = tuple(
         chain(
             *map(iter_configuration_files, requirements)  # type: ignore

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,12 +8,13 @@ from dependence._utilities import WHICH, check_output, is_aliased
 
 
 def test_is_aliased() -> None:
-    if is_aliased("ls"):
+    command: str = "ping"
+    if is_aliased(command):
         shell_output: str = check_output(
-            (WHICH, "ls"),
+            (WHICH, command),
             shell=True,
         )
-        message: str = f"{shell_output}\n!=\n{shutil.which('ls')}"
+        message: str = f"{shell_output}\n!=\n{shutil.which(command)}"
         raise ValueError(message)
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 from subprocess import list2cmdline
+from typing import cast
 
 import pytest
 
@@ -15,12 +16,13 @@ def test_is_aliased() -> None:
         shell_output: str = check_output(
             (WHICH, command),
             shell=True,
-        )
+        ).strip()
         default_shell: str = os.getenv("SHELL") or os.getenv("COMSPEC") or "?"
+        which_command: str = cast("str", shutil.which(command)).strip()
         message: str = (
             f"Output from `{list2cmdline((WHICH, command))}` in "
             f"{default_shell}:\n"
-            f"{shell_output}\n!=\n{shutil.which(command)}"
+            f"{shell_output}\n!=\n{which_command}"
         )
         raise ValueError(message)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pytest
+
+from dependence._utilities import is_aliased
+
+
+def test_is_aliased() -> None:
+    assert not is_aliased("ls")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv", "-s"])

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+import shutil
+
 import pytest
 
-from dependence._utilities import is_aliased
+from dependence._utilities import check_output, is_aliased
 
 
 def test_is_aliased() -> None:
-    assert not is_aliased("ls")
+    if is_aliased("ls"):
+        shell_output: str = check_output(
+            ("which", "ls"),
+            shell=True,
+        )
+        message: str = f"{shell_output}\n!=\n{shutil.which('ls')}"
+        raise ValueError(message)
 
 
 if __name__ == "__main__":

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -4,13 +4,13 @@ import shutil
 
 import pytest
 
-from dependence._utilities import check_output, is_aliased
+from dependence._utilities import WHICH, check_output, is_aliased
 
 
 def test_is_aliased() -> None:
     if is_aliased("ls"):
         shell_output: str = check_output(
-            ("which", "ls"),
+            (WHICH, "ls"),
             shell=True,
         )
         message: str = f"{shell_output}\n!=\n{shutil.which('ls')}"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import shutil
+from subprocess import list2cmdline
 
 import pytest
 
@@ -14,7 +16,12 @@ def test_is_aliased() -> None:
             (WHICH, command),
             shell=True,
         )
-        message: str = f"{shell_output}\n!=\n{shutil.which(command)}"
+        default_shell: str = os.getenv("SHELL") or os.getenv("COMSPEC") or "?"
+        message: str = (
+            f"Output from `{list2cmdline((WHICH, command))}` in "
+            f"{default_shell}:\n"
+            f"{shell_output}\n!=\n{shutil.which(command)}"
+        )
         raise ValueError(message)
 
 


### PR DESCRIPTION
This pull request introduces improved handling of shell command execution in the codebase, particularly for cases where commands like `pip` or `uv` may be aliased in the user's shell environment. The main changes include adding a utility to detect shell aliases, updating how commands are executed to respect these aliases, and making related adjustments to testing and configuration.

**Shell command execution improvements:**

* Added a new `is_aliased` function in `_utilities.py` to detect if a command is aliased in the user's shell, using the `which` command and comparing to `shutil.which`.
* Updated the `check_output` utility to accept `shell` and `env` parameters, and to properly handle command invocation when a shell is required (e.g., when an alias is detected). [[1]](diffhunk://#diff-7499b06a2054b7a11a53b62f702ade792ca19c1a61a06d1509aa67c78321fe7aR195-R196) [[2]](diffhunk://#diff-7499b06a2054b7a11a53b62f702ade792ca19c1a61a06d1509aa67c78321fe7aR211-R227)

**Package installation and upgrade logic:**

* Modified both `_install_requirement_string` in `_utilities.py` and `upgrade` in `upgrade.py` to use the `is_aliased` check for `uv` and `pip`, setting `shell=True` and adjusting the command invocation accordingly if an alias is present. [[1]](diffhunk://#diff-7499b06a2054b7a11a53b62f702ade792ca19c1a61a06d1509aa67c78321fe7aR1122-R1126) [[2]](diffhunk://#diff-7499b06a2054b7a11a53b62f702ade792ca19c1a61a06d1509aa67c78321fe7aR1146-R1162) [[3]](diffhunk://#diff-7499b06a2054b7a11a53b62f702ade792ca19c1a61a06d1509aa67c78321fe7aL1131-R1175) [[4]](diffhunk://#diff-7499b06a2054b7a11a53b62f702ade792ca19c1a61a06d1509aa67c78321fe7aL1156-R1200) [[5]](diffhunk://#diff-43291524d4821d75709cd176c8ee996774b232ba3c3e456371b2526f274c6926L83-R123)

**Testing and configuration:**

* Added a test for the new `is_aliased` function in `test_utilities.py`.
* Updated `pyproject.toml` to set the virtual environment path and adjust test runner arguments for improved test output. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R54) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L88-R92)

These changes ensure that package installation and upgrade commands work correctly even in environments where users have set up shell aliases, improving reliability and user experience.