### PR TITLE
Quote Arguments with Brackets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dependence"
-version = "1.4.0"
+version = "1.4.1"
 description = "A dependency management tool for python projects"
 readme = "README.md"
 license = "MIT"

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -16,7 +16,15 @@ from importlib.metadata import distributions as _get_distributions
 from itertools import chain
 from pathlib import Path
 from shutil import rmtree
-from subprocess import DEVNULL, PIPE, CalledProcessError, list2cmdline, run
+from subprocess import (
+    DEVNULL,
+    PIPE,
+    CalledProcessError,
+    run,
+)
+from subprocess import (
+    list2cmdline as _list2cmdline,
+)
 from traceback import format_exception
 from typing import (
     IO,
@@ -101,6 +109,22 @@ class Undefined:
 
 
 UNDEFINED: Undefined = Undefined()
+
+
+def list2cmdline(args: Iterable[str]) -> str:
+    """
+    This function is a wrapper around `subprocess.list2cmdline` which ensures
+    that arguments containing `[` are properly quoted, making it safe to
+    use with `zsh`.
+    """
+    return _list2cmdline(
+        (
+            f"'{arg}'"
+            if "[" in arg and not (arg.startswith("'") and arg.endswith("'"))
+            else arg
+        )
+        for arg in args
+    )
 
 
 def _undefined() -> Undefined:


### PR DESCRIPTION
This pull request primarily introduces a new utility function to improve subprocess command-line argument handling, especially for compatibility with `zsh`. It also includes a minor version bump to reflect this enhancement.

Enhancements to subprocess utilities:

* Added a new `list2cmdline` function in `src/dependence/_utilities.py` that wraps Python's standard `subprocess.list2cmdline`, ensuring arguments containing `[` are properly quoted for safe use with `zsh`. ([src/dependence/_utilities.pyR114-R129](diffhunk://#diff-7499b06a2054b7a11a53b62f702ade792ca19c1a61a06d1509aa67c78321fe7aR114-R129))
* Refactored imports in `src/dependence/_utilities.py` to alias the standard `list2cmdline` as `_list2cmdline`, supporting the new wrapper function.

Version update:

* Bumped the project version from `1.4.0` to `1.4.1` in `pyproject.toml` to reflect the new functionality.