### PR TITLE
UV Shim Fallback

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "superpowers-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "obra/superpowers-marketplace"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "superpowers@superpowers-marketplace": true
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,5 @@
 {
-  "extraKnownMarketplaces": {
-    "superpowers-marketplace": {
-      "source": {
-        "source": "github",
-        "repo": "obra/superpowers-marketplace"
-      }
-    }
-  },
   "enabledPlugins": {
-    "superpowers@superpowers-marketplace": true
+    "superpowers@claude-plugins-official": true
   }
 }

--- a/.claude/skills/SKILL.md
+++ b/.claude/skills/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: fableplan
+description: |
+    Toggle "Fable Plan Mode" for this repo, on this machine only — plan with
+    Fable 5, execute with Sonnet (opusplan-style). Use when the user runs
+    /fableplan, optionally with "off" to disable, or "1m" to use the
+    1M-context Fable variant.
+---
+
+# Fableplan — plan with Fable 5, execute with Sonnet (opt-in, per-user)
+
+Claude Code has a built-in `opusplan` model setting ("Opus in plan mode,
+Sonnet otherwise") but no Fable equivalent. This skill recreates it by
+combining `opusplan` with the `ANTHROPIC_DEFAULT_OPUS_MODEL` environment
+variable override, which redirects the "opus" alias to Fable 5 — giving
+Fable 5 in plan mode and Sonnet for execution, at lower cost than running
+Fable continuously.
+
+This is **opt-in only**: nothing in this repo enables it by default. Running
+this skill writes to `.claude/settings.local.json` and
+`.claude/fableplan-backup.json` — both gitignored and specific to this
+machine. Nothing is committed, and no other user or repo config is affected.
+
+Adapted from [bapttiste73/fableplan](https://github.com/bapttiste73/fableplan)
+(MIT licensed), retargeted from the user's global `~/.claude/settings.json`
+to this repo's local settings file so the effect stays scoped to this repo.
+
+## Arguments
+
+- *(none)* — enable fableplan locally with `claude-fable-5`
+- `1m` — enable fableplan locally with `claude-fable-5[1m]` (1M context
+  window; higher per-token cost, use deliberately)
+- `off` — disable fableplan locally, reverting to this repo's normal model
+  configuration
+
+## Enabling (no argument, or `1m`)
+
+1. Read `.claude/settings.local.json` (repo-relative). If it does not exist,
+   create it with an empty object first.
+2. If `.claude/fableplan-backup.json` does not exist, create it before changing
+   settings. Record whether `"model"` exists and its current value, and whether
+   `"env"."ANTHROPIC_DEFAULT_OPUS_MODEL"` exists and its current value. This
+   backup represents the pre-fableplan configuration and must not be overwritten
+   on subsequent enables.
+3. Merge the following keys, preserving every other existing setting (notably
+   `permissions` and `defaultMode`, if present):
+   - Set `"model": "opusplan"`.
+   - Under `"env"` (create the object if missing, preserve its other
+     entries), set `"ANTHROPIC_DEFAULT_OPUS_MODEL"` to `"claude-fable-5"` (or
+     `"claude-fable-5[1m]"` if the argument is `1m`).
+4. Validate that both resulting files are valid JSON.
+5. Tell the user:
+   - Fableplan is enabled on this machine: plan mode runs on Fable 5,
+     execution runs on Sonnet.
+   - They must **restart their Claude Code session** for the change to take
+     effect.
+   - The UI will display "Opus Plan Mode" — that label is cosmetic; plan mode
+     actually runs Fable 5.
+   - This only changed gitignored local files — nothing is committed and no
+     other user is affected.
+
+## Disabling (`off`)
+
+1. Read `.claude/settings.local.json`. If it does not exist, there is nothing
+   to do — tell the user fableplan is already off (it was never enabled on
+   this machine).
+2. Read `.claude/fableplan-backup.json`. If it does not exist, do not change
+   `"model"` or `"ANTHROPIC_DEFAULT_OPUS_MODEL"`: their origin cannot be
+   determined safely. Tell the user that fableplan's backup is missing and its
+   settings were left intact.
+3. Otherwise, restore `"model"` and `"env"."ANTHROPIC_DEFAULT_OPUS_MODEL"` to
+   the values recorded in the backup. Remove each key when the backup records
+   that it was absent; drop the `"env"` key entirely if it becomes empty. Leave
+   every other key untouched, then delete `.claude/fableplan-backup.json`.
+4. Validate JSON and tell the user:
+   - Fableplan is disabled on this machine; the repo's normal model
+     configuration applies again.
+   - They must restart their Claude Code session for the change to take
+     effect.
+   - Run `/fableplan` (no argument) at any time to re-enable.
+
+## Important caveats (mention them when enabling for the first time)
+
+- `ANTHROPIC_DEFAULT_OPUS_MODEL` is an undocumented override — a future CLI
+  update could change or remove it.
+- Fable 5 is not available on every plan/account. If requests fail after
+  enabling, run `/fableplan off` to revert.
+- Anything else that resolves the "opus" alias (e.g. fast mode) will also
+  point to Fable while `opusplan` + the env override are active.

--- a/.claude/skills/fableplan/SKILL.md
+++ b/.claude/skills/fableplan/SKILL.md
@@ -18,7 +18,7 @@ Fable continuously.
 
 This is **opt-in only**: nothing in this repo enables it by default. Running
 this skill writes to `.claude/settings.local.json` and
-`.claude/fableplan-backup.json` — both gitignored and specific to this
+`.claude/.fableplan-backup.json` — both gitignored and specific to this
 machine. Nothing is committed, and no other user or repo config is affected.
 
 Adapted from [bapttiste73/fableplan](https://github.com/bapttiste73/fableplan)
@@ -37,7 +37,7 @@ to this repo's local settings file so the effect stays scoped to this repo.
 
 1. Read `.claude/settings.local.json` (repo-relative). If it does not exist,
    create it with an empty object first.
-2. If `.claude/fableplan-backup.json` does not exist, create it before changing
+2. If `.claude/.fableplan-backup.json` does not exist, create it before changing
    settings. Record whether `"model"` exists and its current value, and whether
    `"env"."ANTHROPIC_DEFAULT_OPUS_MODEL"` exists and its current value. This
    backup represents the pre-fableplan configuration and must not be overwritten
@@ -64,14 +64,14 @@ to this repo's local settings file so the effect stays scoped to this repo.
 1. Read `.claude/settings.local.json`. If it does not exist, there is nothing
    to do — tell the user fableplan is already off (it was never enabled on
    this machine).
-2. Read `.claude/fableplan-backup.json`. If it does not exist, do not change
+2. Read `.claude/.fableplan-backup.json`. If it does not exist, do not change
    `"model"` or `"ANTHROPIC_DEFAULT_OPUS_MODEL"`: their origin cannot be
    determined safely. Tell the user that fableplan's backup is missing and its
    settings were left intact.
 3. Otherwise, restore `"model"` and `"env"."ANTHROPIC_DEFAULT_OPUS_MODEL"` to
    the values recorded in the backup. Remove each key when the backup records
    that it was absent; drop the `"env"` key entirely if it becomes empty. Leave
-   every other key untouched, then delete `.claude/fableplan-backup.json`.
+   every other key untouched, then delete `.claude/.fableplan-backup.json`.
 4. Validate JSON and tell the user:
    - Fableplan is disabled on this machine; the repo's normal model
      configuration applies again.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,12 @@ jobs:
       uses: pypa/hatch@install
     - name: test
       run: hatch test -py ${{ matrix.python }}
+  success:
+    name: success
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - lint
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    steps:
+      - run: echo "Success!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ on:
     - tests/**
     - "*_requirements.txt"
     - .github/workflows/test.yml
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ pip-wheel-metadata
 !.flake8
 !.markdownlint.yaml
 !.editorconfig
+!.claude
 site

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Overview
+
+`dependence` is a CLI + library that syncs dependency specifiers in
+`pyproject.toml`/`setup.cfg`/`requirements.txt`/`tox.ini` with what's
+installed. Subcommands (each its own module + `main()`):
+- `update` — rewrite specifiers to match installed versions.
+- `freeze` — recursively resolve a *package's* deps (`name==version`), unlike env-wide `pip freeze`.
+- `upgrade` — `pip install --upgrade` frozen deps, then `update`.
+
+## Commands (run from repo root, via `hatch`)
+
+- `make install` — first-time setup (installs hatch, creates envs).
+- `make format` — `hatch fmt --formatter && hatch fmt --linter && hatch run mypy`. Run before `make test`.
+- `make test` — `hatch fmt --check && hatch run mypy && hatch test -c`.
+- Single test: `hatch test -c -- tests/test_utilities.py::<test_name> -v`
+- `make docs` — build + serve MkDocs.
+- `make upgrade` / `make requirements` — dogfoods `dependence` on its own `pyproject.toml` per hatch env.
+
+## Architecture
+
+- `src/` layout. `dependence.__main__:main` pops `sys.argv[1]` as the
+  subcommand, dynamically imports `dependence.<command>`, calls its
+  `main()`. New subcommand = new module with `main()`, no central registry.
+- `freeze.py`/`update.py`/`upgrade.py` are thin; logic lives in private
+  `_utilities.py` (excluded from coverage).
+- Shared flow: get requirement strings from config
+  (`iter_configuration_file_requirement_strings` /
+  `get_required_distribution_names`) → resolve installed versions
+  (`get_installed_distributions` → `map_pip_list` → `_iter_pip_list`) →
+  apply subcommand transform.
+- `_iter_pip_list` and `_install_requirement_string` (`_utilities.py`)
+  prefer `uv pip ...` when `uv` is on `PATH`, else fall back to
+  `sys.executable -m pip ...`. Preserve this fallback if touching either
+  function (see `docs/superpowers/specs/2026-07-29-uv-shim-pip-fallback-design.md`).
+- `update` only rewrites inclusive specifiers (`~=`, `==`, `>=`, `<=`) and
+  preserves existing granularity (`~=1.2` + installed `1.5.6` → `~=1.5`);
+  unversioned requirements untouched. TOML targeting uses JSON pointers
+  (`--include-pointer`/`--exclude-pointer`; if both given, both must match).
+
+## Conventions
+
+- ruff line length 79, max complexity 10; mypy `disallow_untyped_defs` over
+  `src` and `tests`; ships `py.typed`.
+- Tests use real subprocesses against `tests/test_projects/test_project_{a,b,c}`
+  — don't mock `dependence`'s own interfaces. Coverage `fail_under = 70`.
+- Branches: `feature/...` / `bugfix/...`. Before PR: `make format`, `make test`.
+- Bumping `version` in `pyproject.toml` on `main` triggers release (tag,
+  GitHub release, PyPI publish, docs deploy) — don't bump incidentally.
+- `docs/api/*.md` are mkdocstrings stubs; API docs come from docstrings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/docs/superpowers/plans/2026-07-29-uv-shim-pip-fallback.md
+++ b/docs/superpowers/plans/2026-07-29-uv-shim-pip-fallback.md
@@ -1,0 +1,314 @@
+# `uv` Shim Fallback to `pip` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `dependence`'s `uv`-based package inventory (`_iter_pip_list`)
+and editable reinstall (`_install_requirement_string`) fall back to the target
+interpreter's own `pip` when the `uv` command discovered on `PATH` fails to
+run, instead of raising `CalledProcessError`.
+
+**Architecture:** Both functions currently pick a command shape once — `uv
+pip …` if `shutil.which("uv")` finds anything, else `sys.executable -m pip
+…` — and never reconsider it. Change each to compute *both* command shapes
+when `uv` is found, attempt the `uv` command first, and retry with the `pip`
+command only on `CalledProcessError`. This is additive: when the discovered
+`uv` already works (the common case), the fallback command never executes and
+behavior is unchanged.
+
+**Tech Stack:** Python 3.10+, `subprocess`, `pytest`/`hatch test` (real
+subprocesses only — no mocking of `dependence`'s own interfaces, consistent
+with the existing `tests/test_utilities.py::test_is_aliased` style).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-29-uv-shim-pip-fallback-design.md`.
+- Reproduce the failure with a real, on-`PATH` executable that fails (not a
+  mock/monkeypatch of `dependence`'s own functions) — this repo's existing
+  tests exercise real subprocesses (`test_is_aliased`), and the bug itself is
+  a real-subprocess failure mode.
+- No behavior change when `uv` already works or is absent from `PATH`.
+- Do not narrow the fallback trigger to a specific exit code (e.g. 127
+  specifically) — react to any `CalledProcessError`, matching the existing
+  `check_output` contract.
+- Do not change `dependence`'s public API or CLI (`freeze`, `update`,
+  `upgrade`).
+- Bump `version` in `pyproject.toml` (currently `1.4.1`) as part of this
+  change.
+- Run all commands from the repository root (`/Users/davidbelais/Code/dependence`).
+
+---
+
+### Task 1: Fall back to `pip` in `_iter_pip_list`
+
+**Files:**
+- Modify: `src/dependence/_utilities.py:560-586` (`_iter_pip_list`)
+- Modify: `tests/test_utilities.py`
+
+**Interfaces:**
+- Consumes: nothing new — `shutil.which("uv")`, `sys.executable`,
+  `check_output` (already imported/defined in this module).
+- Produces: `_iter_pip_list` keeps its existing signature and yields the same
+  `(normalized_name, PackageMetadata)` pairs; `map_pip_list()` and everything
+  built on it (`_iter_editable_project_locations`,
+  `map_editable_project_locations`, `refresh_editable_distributions`,
+  `get_installed_distributions`, `get_frozen_requirements`) are unaffected
+  beyond now succeeding in the failure scenario below.
+
+- [ ] **Step 1: Write the failing test**
+
+  In `tests/test_utilities.py`, add a test that puts a real, on-`PATH`
+  executable named `uv` ahead of any working `uv` so `shutil.which("uv")`
+  resolves to it, and asserts `map_pip_list()` still succeeds (falling back
+  to the real interpreter's `pip`):
+
+  ```python
+  import stat
+  import sys
+  from pathlib import Path
+
+  from dependence._utilities import map_pip_list
+
+
+  def test_map_pip_list_falls_back_to_pip_when_uv_cannot_run(
+      tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+  ) -> None:
+      """
+      A `uv` executable that is present on `PATH` but cannot actually run
+      (as happens when a security wrapper, e.g. Aikido Safe Chain's shim,
+      has no real `uv` to delegate to) must not prevent package discovery --
+      `dependence` should fall back to `pip`.
+      """
+      broken_uv: Path = tmp_path.joinpath(
+          "uv.bat" if sys.platform == "win32" else "uv"
+      )
+      broken_uv.write_text(
+          "@exit /b 127\n" if sys.platform == "win32" else "#!/bin/sh\nexit 127\n"
+      )
+      broken_uv.chmod(broken_uv.stat().st_mode | stat.S_IEXEC)
+      monkeypatch.setenv(
+          "PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}"
+      )
+      map_pip_list.cache_clear()
+      try:
+          packages = map_pip_list()
+      finally:
+          map_pip_list.cache_clear()
+      assert packages  # the running interpreter's own site-packages
+  ```
+
+  (Add `import os` and `import pytest` to the existing import block as
+  needed — `monkeypatch` is a built-in pytest fixture, not a mock of
+  `dependence` itself.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+  Run: `hatch test -c -- tests/test_utilities.py::test_map_pip_list_falls_back_to_pip_when_uv_cannot_run -v`
+
+  Expected: FAIL with `subprocess.CalledProcessError` (exit 127), reproducing
+  the reported bug without needing a Safe Chain-wrapped CI runner.
+
+- [ ] **Step 3: Implement the fallback**
+
+  In `src/dependence/_utilities.py`, replace `_iter_pip_list`:
+
+  ```python
+  def _iter_pip_list() -> Iterable[tuple[str, PackageMetadata]]:
+      uv: str | None = shutil.which("uv")
+      pip_command: tuple[str, ...] = (
+          sys.executable,
+          "-m",
+          "pip",
+          "list",
+          "--format=json",
+      )
+      output: str
+      if uv:
+          uv_command: tuple[str, ...] = (
+              uv,
+              "pip",
+              "list",
+              "--python",
+              sys.executable,
+              "--format=json",
+          )
+          try:
+              output = check_output(uv_command)
+          except CalledProcessError:
+              # `uv` was found on `PATH` but could not run (for example, a
+              # CI security wrapper's shim with no real `uv` to delegate
+              # to) -- fall back to this interpreter's own `pip`.
+              output = check_output(pip_command)
+      else:
+          output = check_output(pip_command)
+      metadata: PackageMetadata
+      for metadata in json.loads(output):
+          yield (
+              normalize_name(metadata["name"]),
+              metadata,
+          )
+  ```
+
+  `CalledProcessError` is already imported in this module (used by
+  `is_aliased` and `_install_requirement_string`).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+  Run: `hatch test -c -- tests/test_utilities.py::test_map_pip_list_falls_back_to_pip_when_uv_cannot_run -v`
+
+  Expected: PASS.
+
+- [ ] **Step 5: Run the full test suite for this module**
+
+  Run: `hatch test -c -- tests/test_utilities.py tests/test_freeze.py -v`
+
+  Expected: all pass, including existing `test_is_aliased` and the
+  editable-project freeze tests in `test_freeze.py` — confirming no
+  regression to the (unchanged, `uv`-works) common path.
+
+### Task 2: Fall back to `pip` in `_install_requirement_string`
+
+**Files:**
+- Modify: `src/dependence/_utilities.py:1144-1237` (`_install_requirement_string`)
+- Modify: `tests/test_utilities.py`
+
+**Interfaces:**
+- Consumes: same as Task 1.
+- Produces: `_install_requirement_string` keeps its existing signature and
+  side effect (installs `requirement_string` into `sys.executable`'s
+  environment); on a `uv` failure it installs via `pip` instead, without
+  raising, before falling through to today's error/`--force-reinstall`
+  handling only if the `pip` attempt also fails.
+
+- [ ] **Step 1: Write the failing test**
+
+  Reuse the same broken-`uv`-on-`PATH` technique from Task 1. Install a
+  small real local package editably and assert it succeeds despite the
+  broken `uv`:
+
+  ```python
+  def test_install_requirement_string_falls_back_to_pip_when_uv_cannot_run(
+      tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+  ) -> None:
+      # ... same broken-`uv` PATH setup as the `_iter_pip_list` test ...
+      from dependence._utilities import _install_requirement_string
+
+      project_a = str(
+          Path(__file__)
+          .absolute()
+          .parent.joinpath("test_projects/test_project_a")
+      )
+      _install_requirement_string(project_a, name="test-project-a", editable=True)
+      # Assert success via `pip show`/`importlib.metadata`, then uninstall
+      # to leave the test environment clean.
+  ```
+
+  Use `tests/test_projects/test_project_a` (already used by
+  `tests/test_freeze.py`) rather than inventing a new fixture project.
+  Uninstall the package at the end of the test (`sys.executable -m pip
+  uninstall -y test-project-a`) so the test environment is left as found.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+  Run: `hatch test -c -- tests/test_utilities.py::test_install_requirement_string_falls_back_to_pip_when_uv_cannot_run -v`
+
+  Expected: FAIL with `CalledProcessError` (exit 127) from the broken `uv`.
+
+- [ ] **Step 3: Implement the fallback**
+
+  In `_install_requirement_string`, after the existing `if uv: … else: …`
+  block that builds `command`/`shell` (unchanged), replace the trailing
+  `try`/`except` (currently starting at line 1208) so a `uv`-only failure
+  retries via `pip` before falling into the existing message/reinstall logic:
+
+  ```python
+      try:
+          check_output(command, shell=shell)
+      except CalledProcessError as error:
+          if uv and not shell:
+              pip_command: tuple[str, ...] = (
+                  sys.executable,
+                  "-m",
+                  "pip",
+                  "install",
+                  "--no-deps",
+                  "--no-compile",
+                  *(
+                      ("-e", requirement_string)
+                      if editable
+                      else (requirement_string,)
+                  ),
+              )
+              try:
+                  check_output(pip_command)
+              except CalledProcessError as pip_error:
+                  command = pip_command
+                  error = pip_error
+              else:
+                  return
+          message: str = (
+              # ... existing message-construction, unchanged, now
+              # describing whichever `command`/`error` reached this point ...
+          )
+          ...  # existing body below is otherwise unchanged
+  ```
+
+  Keep the existing message-construction and (for `editable=True`) the
+  `--force-reinstall` retry exactly as today — they now simply operate on
+  `command`/`error`, which may be the `pip` fallback's command/error if `uv`
+  was tried and failed.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+  Run: `hatch test -c -- tests/test_utilities.py::test_install_requirement_string_falls_back_to_pip_when_uv_cannot_run -v`
+
+  Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+  Run: `hatch test -c -v`
+
+  Expected: all tests pass, including `tests/test_freeze.py` (which exercises
+  `refresh_editable_distributions` → `_install_requirement_string` indirectly
+  through editable test projects) and `tests/test_update.py`/`test_upgrade.py`
+  if they touch install paths.
+
+### Task 3: Format, lint, and release
+
+**Files:**
+- Modify: `pyproject.toml:9` (version bump)
+
+- [ ] **Step 1: Format and lint**
+
+  Run: `make format`
+
+  Expected: no diffs beyond the intended changes; no lint/type errors.
+
+- [ ] **Step 2: Bump version**
+
+  Change `version` in `pyproject.toml` from `1.4.1` to `1.4.2` (patch — this
+  is a backward-compatible bug fix, no API change).
+
+- [ ] **Step 3: Full local verification**
+
+  Run: `make test`
+
+  Expected: all tests, formatting, linting, and type-checking pass.
+
+- [ ] **Step 4: Publish**
+
+  Once merged, release per `docs/contributing.md` (`make build`/publish
+  flow already configured in the `Makefile`) so `dependence==1.4.2` is
+  available on PyPI for downstream consumers.
+
+## Verification Checklist
+
+- [ ] `_iter_pip_list` succeeds when `uv` is on `PATH` but cannot run,
+  provided this interpreter's own `pip` can list packages.
+- [ ] `_install_requirement_string`'s editable-reinstall path succeeds under
+  the same condition.
+- [ ] Neither function's behavior changes when `uv` already works or is
+  absent from `PATH` (existing test suite, especially `test_freeze.py`,
+  still passes unmodified).
+- [ ] No mocking of `dependence`'s own functions in the new tests — only a
+  real, broken executable placed on `PATH`.
+- [ ] `pyproject.toml` version bumped to `1.4.2`.

--- a/docs/superpowers/specs/2026-07-29-uv-shim-pip-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-29-uv-shim-pip-fallback-design.md
@@ -1,0 +1,159 @@
+# `uv` Shim Fallback to `pip` — Design Spec
+
+**Date:** 2026-07-29
+**Status:** Draft
+
+## Purpose
+
+Let `dependence` complete its `uv`-based package inventory and editable
+reinstall when the `uv` command discovered on `PATH` cannot actually run,
+falling back to the target interpreter's own `pip`, instead of raising
+`CalledProcessError` and aborting the caller.
+
+## Diagnosis
+
+A downstream consumer, called from a Databricks Asset Bundle's
+`databricks bundle summary` in GitHub Actions, fails with:
+
+```text
+subprocess.CalledProcessError: Command
+('/home/runner/.safe-chain/shims/uv', 'pip', 'list', '--python',
+'.../.venv/bin/python3', '--format=json')' returned non-zero exit status 127.
+```
+
+Traced to `dependence.freeze.get_frozen_requirements` →
+`_utilities.iter_distinct` → `_iter_toml_requirement_strings` →
+`iter_find_requirements_lists` → `iter_find_qualified_lists` →
+`_is_installed_requirement_string` → `is_installed` →
+`get_installed_distributions` → `refresh_editable_distributions` →
+`map_editable_project_locations` → `map_pip_list` → `_iter_pip_list`
+(`src/dependence/_utilities.py:560`), which builds its command from
+`shutil.which("uv")` (`:561`).
+
+The caller's CI environment installs
+[Aikido Safe Chain](https://github.com/AikidoSec/safe-chain), a supply-chain
+security tool that replaces `uv` on `PATH` with a wrapper script
+(`~/.safe-chain/shims/uv`). That wrapper does not run `uv` itself — it strips
+its own directory from `PATH` and execs `safe-chain uv "$@"`, which locates
+and runs whichever *real* `uv` remains on the now-shim-free `PATH`:
+
+```sh
+# ~/.safe-chain/shims/uv (relevant excerpt)
+PATH=$(remove_shim_from_path) exec safe-chain uv "$@"
+```
+
+In the failing step, no real `uv` is on `PATH` (the step runs outside the
+build tool's environment that installed one), so `safe-chain uv pip list …`
+has nothing to delegate to and exits 127. `shutil.which("uv")` still finds
+the shim file itself — `dependence` has no way to distinguish "a working
+`uv`" from "a wrapper that will fail" without attempting to run it.
+
+The same failure mode reaches a second call, `_install_requirement_string`
+(`:1144`), whose own `shutil.which("uv")` (`:1155`) selects the same
+non-functional shim for the editable-reinstall command
+(`refresh_editable_distributions`, `:606`, calls this once per editable
+project after `map_pip_list`/`map_editable_project_locations` succeeds).
+
+This is not unique to Safe Chain — any environment where `uv` resolves on
+`PATH` to something that cannot run (a broken wrapper, a stale shim, a
+permission error) hits the same failure today.
+
+## Current State
+
+Both call sites pick a command shape once, based only on whether
+`shutil.which("uv")` returns a path, and never reconsider that choice:
+
+- `_iter_pip_list` (`_utilities.py:560-586`): builds a `uv pip list …` command
+  when `uv` is found, else `sys.executable -m pip list …`. Calls
+  `check_output(command)` once; a `CalledProcessError` propagates unchanged.
+- `_install_requirement_string` (`_utilities.py:1144-1237`): builds a
+  `uv pip install …` or `pip install …` command the same way, then
+  `check_output(command, shell=shell)`. On failure it already has a *retry*
+  path — but only for the editable case, and only via `--force-reinstall`
+  using the **same** tool that just failed (`:1233-1237`). A tool that cannot
+  run at all (exit 127) fails identically on retry.
+
+Neither function ever falls back from `uv` to `pip` after `uv` has been
+selected — the choice at the top of the function is final.
+
+## Design
+
+### Shared fallback semantics
+
+When a `uv`-based command fails (any nonzero exit, matching the existing
+`check_output`/`CalledProcessError` contract — the failure is not narrowed to
+exit code 127 specifically, since a wrapper can fail in more than one way),
+retry once with the equivalent `sys.executable -m pip` command for the same
+operation. If `uv` was not selected in the first place (not found on `PATH`),
+behavior is unchanged — there is nothing to fall back from.
+
+This is strictly additive: environments where the discovered `uv` already
+works see no behavior change, since the fallback command never executes.
+
+### `_iter_pip_list`
+
+Compute both the `uv`-based and `pip`-based `list` commands whenever `uv` is
+found. Attempt the `uv` command; on `CalledProcessError`, attempt the `pip`
+command and use its output instead. A plain `pip list --format=json` result
+includes the same fields this function consumes today, including
+`editable_project_location` — confirmed by inspection of installed CPython
+`pip` output — so no downstream field-mapping changes are needed.
+
+### `_install_requirement_string`
+
+Compute both the `uv`-based and `pip`-based `install` commands whenever `uv`
+is found. Attempt the `uv` command; on `CalledProcessError`, attempt the
+`pip` command before falling through to the function's existing
+error-message construction and (for editable installs) `--force-reinstall`
+retry. If the `pip` fallback succeeds, return normally — no error is raised
+and no message is printed. If the `pip` fallback also fails, the existing
+downstream logic proceeds using the `pip` command and its error, since `uv`
+has already proven unusable.
+
+### Scope boundary
+
+This changes only how `dependence` locates a *working* package manager for
+its own read (`pip list`) and local editable-install operations — no
+resolution, no third-party version selection, no network behavior beyond
+what the caller's chosen tool (`uv` or `pip`) already performs for a
+`--no-deps` local/editable install. `dependence` does not attempt to detect
+or work around specific wrapper tools (Safe Chain or otherwise) by name; it
+only reacts to the command it chose failing to run.
+
+## Validation
+
+| Scenario | Expected result |
+| --- | --- |
+| `uv` on `PATH` runs successfully | Behavior unchanged; `pip` fallback command never executes. |
+| No `uv` on `PATH` | Behavior unchanged; `pip` command used directly, as today. |
+| `uv` on `PATH` is a non-functional wrapper (e.g. exits 127) | `pip list`/`pip install` fallback runs and succeeds; the caller sees no exception. |
+| `uv` on `PATH` fails and the `pip` fallback also fails (list) | The original failure mode is preserved: `CalledProcessError` propagates. |
+| `uv` on `PATH` fails and the `pip` fallback also fails (editable install) | Existing error-message and `--force-reinstall` retry behavior applies, now describing the `pip` attempt. |
+| Editable project's `editable_project_location` metadata | Present and equivalent whether discovered via `uv pip list` or `pip list`. |
+
+Reproduce the failing wrapper without mocking `dependence`'s own interfaces:
+place a real, on-`PATH` executable (a short script that exits 127) ahead of
+any working `uv`, so `shutil.which("uv")` resolves to it. This exercises the
+real subprocess path exactly as a Safe Chain-wrapped CI runner does.
+
+## Acceptance Criteria
+
+- `_iter_pip_list` (and therefore `map_pip_list`, `get_frozen_requirements`,
+  and every downstream consumer such as
+  `refresh_editable_distributions`/`get_installed_distributions`) succeeds
+  when `uv` is present on `PATH` but cannot run, provided the interpreter's
+  own `pip` can.
+- `_install_requirement_string`'s editable-reinstall path succeeds under the
+  same condition.
+- No change in behavior when `uv` already works, or when `uv` is absent.
+- No change to which package manager governs dependency *resolution* for
+  full installs elsewhere in `dependence` or its callers — this only affects
+  the two call sites identified above.
+
+## Out of Scope
+
+- Detecting or special-casing Safe Chain (or any other specific wrapper) by
+  name.
+- Changing `dependence`'s public API or CLI (`freeze`, `update`, `upgrade`).
+- Retrying more than once per call, or adding configurable retry policy.
+- Any change in in dependent libraries/applications

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dependence"
-version = "1.4.1"
+version = "1.4.2"
 description = "A dependency management tool for python projects"
 readme = "README.md"
 license = "MIT"

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -548,9 +548,9 @@ def is_aliased(command: str) -> bool:
         # The command does not exist
         return False
     try:
-        shell_output: str = check_output(
+        shell_output: str = check_output(  # noqa: S604
             (WHICH, command),
-            shell=True,  # noqa: S604
+            shell=True,
         )
     except CalledProcessError:
         return False

--- a/src/dependence/_utilities.py
+++ b/src/dependence/_utilities.py
@@ -408,7 +408,7 @@ def iter_find_qualified_lists(
     if isinstance(data, dict):
         value: Any
         for value in data.values():
-            if isinstance(value, (list, dict)):
+            if isinstance(value, list | dict):
                 yield from iter_find_qualified_lists(
                     value, item_condition, exclude_object_ids
                 )
@@ -418,7 +418,7 @@ def iter_find_qualified_lists(
         for item in data:
             if not item_condition(item):
                 matched = False
-            if isinstance(item, (list, dict)):
+            if isinstance(item, list | dict):
                 yield from iter_find_qualified_lists(
                     item, item_condition, exclude_object_ids
                 )
@@ -548,9 +548,9 @@ def is_aliased(command: str) -> bool:
         # The command does not exist
         return False
     try:
-        shell_output: str = check_output(  # noqa: S604
+        shell_output: str = check_output(
             (WHICH, command),
-            shell=True,
+            shell=True,  # noqa: S604
         )
     except CalledProcessError:
         return False
@@ -559,9 +559,16 @@ def is_aliased(command: str) -> bool:
 
 def _iter_pip_list() -> Iterable[tuple[str, PackageMetadata]]:
     uv: str | None = shutil.which("uv")
-    command: tuple[str, ...]
+    pip_command: tuple[str, ...] = (
+        sys.executable,
+        "-m",
+        "pip",
+        "list",
+        "--format=json",
+    )
+    output: str
     if uv:
-        command = (
+        uv_command: tuple[str, ...] = (
             uv,
             "pip",
             "list",
@@ -569,17 +576,17 @@ def _iter_pip_list() -> Iterable[tuple[str, PackageMetadata]]:
             sys.executable,
             "--format=json",
         )
+        try:
+            output = check_output(uv_command)
+        except CalledProcessError:
+            # `uv` was found on `PATH` but could not run (for example, a
+            # CI security wrapper's shim with no real `uv` to delegate
+            # to) -- fall back to this interpreter's own `pip`.
+            output = check_output(pip_command)
     else:
-        # If `uv` is not available, use `pip`
-        command = (
-            sys.executable,
-            "-m",
-            "pip",
-            "list",
-            "--format=json",
-        )
+        output = check_output(pip_command)
     metadata: PackageMetadata
-    for metadata in json.loads(check_output(command)):
+    for metadata in json.loads(output):
         yield (
             normalize_name(metadata["name"]),
             metadata,
@@ -809,7 +816,7 @@ def iter_find_requirements_lists(
                 include_pointers,
             ),
         ):
-            if isinstance(included_element, (list, dict)):
+            if isinstance(included_element, list | dict):
                 yield from iter_find_qualified_lists(
                     included_element,
                     item_condition=_is_installed_requirement_string,
@@ -1207,7 +1214,37 @@ def _install_requirement_string(
         )
     try:
         check_output(command, shell=shell)
-    except CalledProcessError as error:
+    except CalledProcessError as uv_error:
+        # Reassigned below if the `pip` fallback also fails, so the
+        # rest of this handler (including the bare re-raise) reports
+        # whichever command actually produced the *last* failure.
+        # Keep this as `except ... as uv_error` + assignment (not
+        # `except ... as error`) -- `error` is deliberately mutable.
+        error: CalledProcessError = uv_error
+        if uv:
+            # `uv` was found on `PATH` but could not run (for example, a
+            # CI security wrapper's shim with no real `uv` to delegate
+            # to) -- fall back to this interpreter's own `pip`.
+            pip_command: tuple[str, ...] = (
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--no-deps",
+                "--no-compile",
+                *(
+                    ("-e", requirement_string)
+                    if editable
+                    else (requirement_string,)
+                ),
+            )
+            try:
+                check_output(pip_command)
+            except CalledProcessError as pip_error:
+                command = pip_command
+                error = pip_error
+            else:
+                return
         message: str = (
             (
                 f"\nCould not install {name}:"
@@ -1229,7 +1266,20 @@ def _install_requirement_string(
         )
         if not editable:
             print(message)  # noqa: T201
-            raise
+            # Raise `error` explicitly (not a bare `raise`) so that if
+            # the `pip` fallback above also failed, we propagate *that*
+            # failure -- a bare `raise` here would re-raise `uv_error`
+            # because the "currently handled exception" reverts to it
+            # once the nested try/except above exits without itself
+            # re-raising. When the fallback was never attempted (or
+            # wasn't needed), `error` is still `uv_error`, so this is
+            # equivalent to a bare `raise`. We don't use
+            # `raise error from uv_error`: when `error is uv_error`
+            # that would set `error.__cause__` to itself, which is an
+            # observable oddity for no benefit -- Python's implicit
+            # exception chaining already sets `error.__context__` to
+            # `uv_error` whenever they are different objects.
+            raise error  # noqa: B904 -- see comment above; `from` is intentionally omitted
         try:
             check_output((*command, "--force-reinstall"), shell=shell)
         except CalledProcessError:

--- a/src/dependence/freeze.py
+++ b/src/dependence/freeze.py
@@ -118,7 +118,7 @@ def get_frozen_requirements(  # noqa: C901
         exclude_pointers: A tuple of JSON pointers indicating elements to
             exclude (defaults to no exclusions). Only applies to TOML files.
     """
-    if isinstance(requirements, (str, Path)):
+    if isinstance(requirements, str | Path):
         requirements = {str(requirements)}
     else:
         requirements = set(map(str, requirements))

--- a/src/dependence/update.py
+++ b/src/dependence/update.py
@@ -507,7 +507,7 @@ def update(
             files (including pyproject.toml), and is ignored for all other
             file types.
     """
-    if isinstance(paths, (str, Path)):
+    if isinstance(paths, str | Path):
         paths = (paths,)
 
     def update_(path: str | Path) -> None:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -9,6 +9,8 @@ import sys
 from subprocess import list2cmdline
 from typing import TYPE_CHECKING, cast
 
+from dependence._utilities import _install_requirement_string
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -77,8 +79,6 @@ def test_install_requirement_string_falls_back_to_pip_when_uv_cannot_run(
     currently supported Python, so those fixtures cannot be installed
     for real. A small installable package is built here instead.
     """
-    from dependence._utilities import _install_requirement_string
-
     broken_uv: Path = tmp_path.joinpath(
         "uv.bat" if sys.platform == "win32" else "uv"
     )
@@ -141,7 +141,6 @@ def test_install_requirement_string_raises_pip_error_when_uv_and_pip_both_fail(
     the nested `try`/`except` for the `pip` fallback exits without
     itself re-raising.
     """
-    from dependence._utilities import _install_requirement_string
 
     broken_uv: Path = tmp_path.joinpath(
         "uv.bat" if sys.platform == "win32" else "uv"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import importlib.metadata
 import os
 import shutil
+import stat
+import subprocess
+import sys
 from subprocess import list2cmdline
-from typing import cast
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import pytest
 
-from dependence._utilities import WHICH, check_output, is_aliased
+from dependence._utilities import WHICH, check_output, is_aliased, map_pip_list
 
 
 def test_is_aliased() -> None:
@@ -25,6 +32,160 @@ def test_is_aliased() -> None:
             f"{shell_output}\n!=\n{which_command}"
         )
         raise ValueError(message)
+
+
+def test_map_pip_list_falls_back_to_pip_when_uv_cannot_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A `uv` executable that is present on `PATH` but cannot actually run
+    (as happens when a security wrapper, e.g. Aikido Safe Chain's shim,
+    has no real `uv` to delegate to) must not prevent package discovery --
+    `dependence` should fall back to `pip`.
+    """
+    broken_uv: Path = tmp_path.joinpath(
+        "uv.bat" if sys.platform == "win32" else "uv"
+    )
+    broken_uv.write_text(
+        "@exit /b 127\n"
+        if sys.platform == "win32"
+        else "#!/bin/sh\nexit 127\n"
+    )
+    broken_uv.chmod(broken_uv.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+    map_pip_list.cache_clear()
+    try:
+        packages = map_pip_list()
+    finally:
+        map_pip_list.cache_clear()
+    assert packages  # the running interpreter's own site-packages
+
+
+def test_install_requirement_string_falls_back_to_pip_when_uv_cannot_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A `uv` executable that is present on `PATH` but cannot actually run
+    must not prevent installation -- `dependence` should fall back to
+    `pip` when installing a requirement string.
+
+    Note: `tests/test_projects/test_project_a` (and its siblings) pin
+    `setuptools~=0.0` in `[build-system] requires`, on purpose, to test
+    that "zero version" pins survive `dependence`'s update logic
+    untouched (see `test_update.py::test_get_updated_pyproject_toml_a`).
+    That pin resolves to a setuptools release too old to build on any
+    currently supported Python, so those fixtures cannot be installed
+    for real. A small installable package is built here instead.
+    """
+    from dependence._utilities import _install_requirement_string
+
+    broken_uv: Path = tmp_path.joinpath(
+        "uv.bat" if sys.platform == "win32" else "uv"
+    )
+    broken_uv.write_text(
+        "@exit /b 127\n"
+        if sys.platform == "win32"
+        else "#!/bin/sh\nexit 127\n"
+    )
+    broken_uv.chmod(broken_uv.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+    is_aliased.cache_clear()
+    package_name: str = "pip-fallback-pkg"
+    package_directory: Path = tmp_path.joinpath("pip_fallback_pkg")
+    package_directory.joinpath("pip_fallback_pkg").mkdir(parents=True)
+    package_directory.joinpath("pip_fallback_pkg", "__init__.py").write_text(
+        ""
+    )
+    package_directory.joinpath("pyproject.toml").write_text(
+        "[build-system]\n"
+        'requires = ["setuptools>=61"]\n'
+        'build-backend = "setuptools.build_meta"\n'
+        "\n"
+        "[project]\n"
+        f'name = "{package_name}"\n'
+        'version = "0.0.0"\n'
+    )
+    try:
+        _install_requirement_string(
+            str(package_directory), name=package_name, editable=True
+        )
+        assert importlib.metadata.distribution(package_name)
+    finally:
+        is_aliased.cache_clear()
+        subprocess.run(
+            (
+                sys.executable,
+                "-m",
+                "pip",
+                "uninstall",
+                "-y",
+                package_name,
+            ),
+            check=False,
+            capture_output=True,
+        )
+
+
+def test_install_requirement_string_raises_pip_error_when_uv_and_pip_both_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    When `uv` is present on `PATH` but cannot actually run *and* the
+    `pip` fallback also fails, the exception propagated to the caller
+    must describe the `pip` failure -- not the original `uv` failure.
+
+    A bare `raise` in the `not editable` branch of
+    `_install_requirement_string` would instead re-raise the `uv`
+    failure, because Python's exception-context mechanism reverts the
+    "currently handled exception" to the outer `except` clause once
+    the nested `try`/`except` for the `pip` fallback exits without
+    itself re-raising.
+    """
+    from dependence._utilities import _install_requirement_string
+
+    broken_uv: Path = tmp_path.joinpath(
+        "uv.bat" if sys.platform == "win32" else "uv"
+    )
+    broken_uv.write_text(
+        "@exit /b 127\n"
+        if sys.platform == "win32"
+        else "#!/bin/sh\nexit 127\n"
+    )
+    broken_uv.chmod(broken_uv.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+    is_aliased.cache_clear()
+    # A requirement string that isn't a valid package name and doesn't
+    # exist as a path -- `pip` will reject it immediately (no network
+    # access required), so it legitimately fails too.
+    invalid_requirement: str = str(
+        tmp_path.joinpath("nonexistent", "path", "to", "pkg")
+    )
+    try:
+        with pytest.raises(subprocess.CalledProcessError) as exception_info:
+            _install_requirement_string(
+                invalid_requirement, name="", editable=False
+            )
+    finally:
+        is_aliased.cache_clear()
+    error: subprocess.CalledProcessError = exception_info.value
+    # The propagated error must be `pip`'s, not `uv`'s. Checking
+    # `error.cmd` directly (rather than searching the command line
+    # for the substring "pip") discriminates the two: `uv`'s command
+    # is `uv pip install ...`, which also contains "pip" as a
+    # sub-argument, so a substring check would pass even if `uv`'s
+    # error were propagated by mistake.
+    assert error.cmd[:3] == (sys.executable, "-m", "pip")
+    assert error.returncode != 127
+    command_line: str = list2cmdline(error.cmd)
+    assert invalid_requirement in command_line
+    # The `uv` failure (return code 127) must be preserved as the
+    # *implicit* exception context -- `_install_requirement_string`
+    # raises the `pip` error with a bare `raise error` (not
+    # `raise error from uv_error`), so `__cause__` is `None` and it is
+    # Python's automatic exception chaining that sets `__context__`.
+    assert error.__cause__ is None
+    assert isinstance(error.__context__, subprocess.CalledProcessError)
+    assert error.__context__.returncode == 127
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces several documentation updates and configuration changes to improve the developer experience and clarify project workflows. The most significant addition is a detailed implementation plan for adding a fallback from `uv` to `pip` in the `dependence` package, ensuring robust package management even when `uv` is unavailable or fails. Additional changes include new documentation for project architecture and conventions, updates to workflow permissions, and the introduction of a new Claude plugin and skill.

**Documentation and Project Architecture:**

* Added `AGENTS.md` detailing the architecture, commands, and conventions of the `dependence` project, including its CLI structure, testing strategy, and guidelines for contributors.
* Added `CLAUDE.md` as a reference pointer to `AGENTS.md` for agentic workers.
* Added a comprehensive implementation plan in `docs/superpowers/plans/2026-07-29-uv-shim-pip-fallback.md` for supporting fallback from `uv` to `pip` in key package management functions, including test strategies, code changes, and release steps.

**Configuration and Workflow:**

* Updated `.github/workflows/test.yml` to explicitly set `contents: read` permissions and added a `success` job that reports when all tests and linting pass. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R14-R15) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R43-R51)
* Enabled the official Claude Superpowers plugin in `.claude/settings.json`.
* Introduced a new Claude skill `fableplan` in `.claude/skills/fableplan/SKILL.md`, allowing per-user toggling of "Fable Plan Mode" for advanced planning and execution workflows.